### PR TITLE
fix: 8.0.0 has not been released yet 

### DIFF
--- a/.ci/scripts/tag-metricbeats.sh
+++ b/.ci/scripts/tag-metricbeats.sh
@@ -7,5 +7,7 @@ VERSION=$(echo "${DOCKER_IMAGE}" | sed 's#.*metricbeat-oss-##g; s#-linux.*##g')
 
 # https://docs.docker.com/engine/reference/commandline/import/
 # shellcheck disable=SC2002
-cat "${DOCKER_IMAGE}" | docker import - docker.elastic.co/beats/metricbeat-oss:"${VERSION}"
-docker inspect docker.elastic.co/beats/metricbeat-oss:"${VERSION}"
+cat "${DOCKER_IMAGE}" | docker import - docker.elastic.co/beats/metricbeat-oss:"${VERSION}-SNAPSHOT"
+docker tag docker.elastic.co/beats/metricbeat-oss:"${VERSION}-SNAPSHOT" docker.elastic.co/beats/metricbeat-oss:"${VERSION}"
+docker inspect docker.elastic.co/beats/metricbeat-oss:"${VERSION}-SNAPSHOT"
+docker images docker.elastic.co/beats/metricbeat-oss

--- a/.ci/scripts/tag-metricbeats.sh
+++ b/.ci/scripts/tag-metricbeats.sh
@@ -8,6 +8,5 @@ VERSION=$(echo "${DOCKER_IMAGE}" | sed 's#.*metricbeat-oss-##g; s#-linux.*##g')
 # https://docs.docker.com/engine/reference/commandline/import/
 # shellcheck disable=SC2002
 cat "${DOCKER_IMAGE}" | docker import - docker.elastic.co/beats/metricbeat-oss:"${VERSION}-SNAPSHOT"
-docker tag docker.elastic.co/beats/metricbeat-oss:"${VERSION}-SNAPSHOT" docker.elastic.co/beats/metricbeat-oss:"${VERSION}"
 docker inspect docker.elastic.co/beats/metricbeat-oss:"${VERSION}-SNAPSHOT"
 docker images docker.elastic.co/beats/metricbeat-oss

--- a/features/apache.feature
+++ b/features/apache.feature
@@ -6,5 +6,7 @@ Scenario Outline: Check module is sending metrics to a file
   Then metricbeat outputs metrics to the file "apache-<apache_version>.metrics"
 Examples:
 | apache_version | metricbeat_version |
-| 2.2  | 8.0.0 |
-| 2.4  | 8.0.0 |
+| 2.2  | 7.3.0 |
+| 2.2  | 8.0.0-SNAPSHOT |
+| 2.4  | 7.3.0 |
+| 2.4  | 8.0.0-SNAPSHOT |

--- a/features/mysql.feature
+++ b/features/mysql.feature
@@ -6,6 +6,9 @@ Scenario Outline: Check module is sending metrics to a file
   Then metricbeat outputs metrics to the file "mysql-<mysql_version>.metrics"
 Examples:
 | mysql_version | metricbeat_version |
-| 5.6  | 8.0.0 |
-| 5.7  | 8.0.0 |
-| 8.0  | 8.0.0 |
+| 5.6  | 7.3.0 |
+| 5.7  | 7.3.0 |
+| 8.0  | 7.3.0 |
+| 5.6  | 8.0.0-SNAPSHOT |
+| 5.7  | 8.0.0-SNAPSHOT |
+| 8.0  | 8.0.0-SNAPSHOT |


### PR DESCRIPTION
so let's use 8.0.0-SNAPSHOT and tag the metricbeats one to ensure it's consumed as SNAPSHOT later on

## Highlights
- enable `8.0.0-SNAPSHOT` versions to be tested
- metricbeats `8.0.0-SNAPSHOT` has to be created on the fly with the docker import. 