### PR TITLE
ci: enable FEATURE env variable to test specific features

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
   parameters {
     string(name: 'GO_VERSION', defaultValue: '1.12.7', description: "Go version to use.")
     string(name: 'PR', defaultValue: '', description: "PR to be tested out")
+    string(name: 'FEATURE', defaultValue: '', description: 'What feature to be tested out (feature name or ALL are allowed)')
     string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered by another parent stream.')
     string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered by another parent stream.')
     string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered by another parent stream.')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
   parameters {
     string(name: 'GO_VERSION', defaultValue: '1.12.7', description: "Go version to use.")
     string(name: 'PR', defaultValue: '', description: "PR to be tested out")
-    string(name: 'FEATURE', defaultValue: '', description: 'What feature to be tested out (feature name or ALL are allowed)')
+    string(name: 'FEATURE', defaultValue: '', description: 'What feature to be tested out (feature filename or all are allowed)')
     string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered by another parent stream.')
     string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered by another parent stream.')
     string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered by another parent stream.')

--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -8,10 +8,19 @@ rm -rf outputs || true
 mkdir -p outputs
 REPORT=outputs/junit-functional-tests
 
+## Parse FEATURE if ALL
+if [ -n "${FEATURE}" ] ; then
+  if [ "${FEATURE}" == "all" ] ; then
+    FEATURE=''
+  fi
+else
+  FEATURE=''
+fi
+
 ## Generate test report even if make failed.
 set +e
 exit_status=0
-if ! REPORT=${REPORT} make functional-test-ci ; then
+if ! REPORT=${REPORT} FEATURE=${FEATURE} make functional-test-ci ; then
   echo 'ERROR: functional-test-ci failed'
   exit_status=1
 fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TEST_TIMEOUT?=5m
 REPORT?=report.xml
+FEATURE?=*.feature
 .PHONY: install-godog
 install-godog:
 	go get github.com/DATA-DOG/godog/cmd/godog
@@ -18,4 +19,4 @@ functional-test: install-godog
 
 .PHONY: functional-test-ci
 functional-test-ci: install-godog
-	godog --format=junit | tee ${REPORT} ; test $${PIPESTATUS[0]} -eq 0
+	godog --format=junit features/${FEATURE} | tee ${REPORT} ; test $${PIPESTATUS[0]} -eq 0


### PR DESCRIPTION
## Highlights
- Let's enable to test a specific feature rather than all of them
- It does support `all` or `<featureName>.feature`, for instance: `apache.feature`

## Test cases
- All
`GO_VERSION=1.12.7 GO111MODULE=on FEATURE=all .ci/scripts/functional-test.sh`

```
...
godog --format=junit features/ | tee outputs/junit-functional-tests ; test ${PIPESTATUS[0]} -eq 0
```

- Apache.feature
`GO_VERSION=1.12.7 GO111MODULE=on FEATURE=apache.feature .ci/scripts/functional-test.sh`

```
...
godog --format=junit features/apache.feature | tee outputs/junit-functional-tests ; test ${PIPESTATUS[0]} -eq 0
```

- Empty
` GO_VERSION=1.12.7 GO111MODULE=on FEATURE= .ci/scripts/functional-test.sh`

```
...
godog --format=junit features/ | tee outputs/junit-functional-tests ; test ${PIPESTATUS[0]} -eq 0
```

- Makefile
`GO_VERSION=1.12.7 GO111MODULE=on FEATURE= make functional-test-ci`

```
godog --format=junit features/ | tee report.xml ; test ${PIPESTATUS[0]} -eq 0
```

- Makefile with FEATURE
`GO_VERSION=1.12.7 GO111MODULE=on FEATURE=apache.feature .ci/scripts/functional-test.sh`

```
godog --format=junit features/apache.feature | tee outputs/junit-functional-tests ; test ${PIPESTATUS[0]} -eq 0
```

- Makefile with unexisting feature
`GO_VERSION=1.12.7 GO111MODULE=on FEATURE=foo.feature .ci/scripts/functional-test.sh`

```
godog --format=junit features/foo.feature | tee outputs/junit-functional-tests ; test ${PIPESTATUS[0]} -eq 0
Validating required tools...
docker is present at /usr/local/bin/docker
feature path "features/foo.feature" is not available
```