### PR TITLE
(#15) Fix path for release artefacts

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -134,7 +134,7 @@ def generateStep(Map params = [:]){
       } catch(e) {
         error(e.toString())
       } finally {
-        archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/.github/releases/download/**"
+        archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/cli/.github/releases/download/**"
       }
     }
   }


### PR DESCRIPTION
The build script is located at `./cli`, so it will create the released artefacts at that path