### PR TITLE
(#22) Create a simple DSL for querying elasticsearch

### DIFF
--- a/metricbeat-tests/.gitignore
+++ b/metricbeat-tests/.gitignore
@@ -7,3 +7,4 @@ outputs/*
 .github/releases
 
 *.swp
+op

--- a/metricbeat-tests/elasticsearch.go
+++ b/metricbeat-tests/elasticsearch.go
@@ -18,6 +18,50 @@ type searchResult struct {
 	Result map[string]interface{}
 }
 
+type queryBuilder map[string]interface{}
+
+func (b queryBuilder) Build(q elasticsearchQuery) queryBuilder {
+	b["query"] = q
+
+	return b
+}
+
+type elasticsearchQuery map[string]boolQuery
+
+func (q elasticsearchQuery) WithBool(b boolQuery) elasticsearchQuery {
+	q["bool"] = b
+
+	return q
+}
+
+type boolQuery map[string]mustQuery
+
+func (b boolQuery) WithMust(m mustQuery) boolQuery {
+	b["must"] = m
+
+	return b
+}
+
+type mustQuery []matchQuery
+
+func (mu mustQuery) WithMatches(mas ...matchQuery) mustQuery {
+	for _, m := range mas {
+		mu = append(mu, m)
+	}
+
+	return mu
+}
+
+type matchQuery map[string]interface{}
+
+func (m matchQuery) WithMatchEntry(e matchEntry) matchQuery {
+	m["match"] = e
+
+	return m
+}
+
+type matchEntry map[string]interface{}
+
 // getElasticsearchClient returns a client connected to the running elasticseach, defined
 // at configuration level. Then we will inspect the running container to get its port bindings
 // and from them, get the one related to the Elasticsearch port (9200). As it is bound to a

--- a/metricbeat-tests/runner_test.go
+++ b/metricbeat-tests/runner_test.go
@@ -171,28 +171,24 @@ func thereAreNoErrorsInTheIndex(index string) error {
 	// no collitions between different test cases should appear
 	esIndexName += "-*"
 
-	esQuery := map[string]interface{}{
-		"query": map[string]interface{}{
-			"bool": map[string]interface{}{
-				"must": []map[string]interface{}{
-					{
-						"match": map[string]interface{}{
-							"event.module": query.EventModule,
-						},
-					},
-					{
-						"match": map[string]interface{}{
-							"service.version": query.ServiceVersion,
-						},
-					},
-				},
-			},
-		},
-	}
+	must := mustQuery{}.WithMatches(
+		matchQuery{}.WithMatchEntry(
+			matchEntry{
+				"event.module": query.EventModule,
+			}),
+		matchQuery{}.WithMatchEntry(
+			matchEntry{
+				"service.version": query.ServiceVersion,
+			}),
+	)
+
+	b := boolQuery{}.WithMust(must)
+	q := elasticsearchQuery{}.WithBool(b)
+	builder := queryBuilder{}
 
 	stackName := "metricbeat"
 
-	result, err := retrySearch(stackName, esIndexName, esQuery, queryMaxAttempts)
+	result, err := retrySearch(stackName, esIndexName, builder.Build(q), queryMaxAttempts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It simplifies the creation of the queries used in this POC.

Spoiler: it just covers this use case: a query > bool > must > match query !