### PR TITLE
Bug fixes

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -304,7 +304,7 @@ func newConfig(workspace string) {
 }
 
 func checkConfigFile(workspace string) {
-	found, err := exists(workspace)
+	found, err := exists(path.Join(workspace, fileName))
 	if found && err == nil {
 		return
 	}

--- a/cli/services/service.go
+++ b/cli/services/service.go
@@ -243,7 +243,7 @@ func (s *DockerService) Run() (testcontainers.Container, error) {
 		ExposedPorts: exposedPorts,
 		Labels:       s.Labels,
 		Name:         s.ContainerName,
-		SkipReaper:   !s.Daemon,
+		SkipReaper:   s.Daemon,
 		WaitingFor:   s.WaitFor,
 	}
 

--- a/metricbeat-tests/.gitignore
+++ b/metricbeat-tests/.gitignore
@@ -7,3 +7,4 @@ outputs/*
 .github/releases
 
 *.swp
+op

--- a/metricbeat-tests/runner_test.go
+++ b/metricbeat-tests/runner_test.go
@@ -180,11 +180,6 @@ func thereAreNoErrorsInTheIndex(index string) error {
 							"event.module": query.EventModule,
 						},
 					},
-					{
-						"match": map[string]interface{}{
-							"service.version": query.ServiceVersion,
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
## What is this PR doing?
It fixes two bugs discovered while preparing a demo: Closes #31, Closes #32, Closes #35

- #31 is related to an error when checking the existence of the configuration file. It simply checked for the parent directory, which is wrong.
- #32 comes from the need of fixing an upstream change (https://github.com/testcontainers/testcontainers-go/pull/82)
- #35 if we filter by `service.version` field, then document errors won't be added to the response