### PR TITLE
(#46) Use qualified name for packr builder's Docker Hub image

### DIFF
--- a/cli/build.sh
+++ b/cli/build.sh
@@ -39,5 +39,5 @@ fi
 
 echo ">>> Building for ${GOOS}/${GOARCH}"
 docker run --rm -v "$(pwd)":${GO_WORKSPACE} -w ${GO_WORKSPACE} \
-    -e GOOS=${GOOS} -e GOARCH=${GOARCH} drud/golang-build-container:${GO_VERSION} \
+    -e GOOS=${GOOS} -e GOARCH=${GOARCH} registry.hub.docker.com/drud/golang-build-container:${GO_VERSION} \
     packr2 build -v -o ${GO_WORKSPACE}/.github/releases/download/${VERSION}/${goos}${arch}-op${extension}


### PR DESCRIPTION
For some reason docker behaves differently on CI than it does locally.

My local version accepts running the `drud/golang-build-container:v1.12.7` directly, which seems to fail on CI build nodes.

### docker version
```shell
Client: Docker Engine - Community
 Version:           19.03.2
 API version:       1.40
 Go version:        go1.12.8
 Git commit:        6a30dfc
 Built:             Thu Aug 29 05:26:49 2019
 OS/Arch:           darwin/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.2
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.8
  Git commit:       6a30dfc
  Built:            Thu Aug 29 05:32:21 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.2.6
  GitCommit:        894b81a4b802e4eb2a91d1ce216b8817763c29fb
 runc:
  Version:          1.0.0-rc8
  GitCommit:        425e105d5a03fabd737a126ad93d62a9eeede87f
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```