### PR TITLE
(#44) random index name

### DIFF
--- a/cli/services/manager.go
+++ b/cli/services/manager.go
@@ -36,7 +36,7 @@ func (sm *DockerServiceManager) AddServicesToCompose(stack string, composeNames 
 	newComposeNames := []string{stack}
 	newComposeNames = append(newComposeNames, composeNames...)
 
-	return executeCompose(sm, false, newComposeNames, []string{"up", "-d"}, env)
+	return executeCompose(sm, true, newComposeNames, []string{"up", "-d"}, env)
 }
 
 // RemoveServicesFromCompose removes services from a running docker compose
@@ -53,7 +53,7 @@ func (sm *DockerServiceManager) RemoveServicesFromCompose(stack string, composeN
 		command := []string{"rm", "-fvs"}
 		command = append(command, composeName)
 
-		err := executeCompose(sm, false, newComposeNames, command, map[string]string{})
+		err := executeCompose(sm, true, newComposeNames, command, map[string]string{})
 		if err != nil {
 			log.WithFields(log.Fields{
 				"command":  command,
@@ -106,8 +106,8 @@ func (sm *DockerServiceManager) StopCompose(isStack bool, composeNames []string)
 func executeCompose(sm *DockerServiceManager, isStack bool, composeNames []string, command []string, env map[string]string) error {
 	composeFilePaths := make([]string, len(composeNames))
 	for i, composeName := range composeNames {
-		b := isStack
-		if i == 0 && !b {
+		b := false
+		if i == 0 && isStack {
 			b = true
 		}
 

--- a/metricbeat-tests/runner_test.go
+++ b/metricbeat-tests/runner_test.go
@@ -48,9 +48,7 @@ type MetricbeatTestSuite struct {
 // As we are using an index per scenario outline, with an index name formed by metricbeat-version1-module-version2,
 // and because of the ILM is configured on metricbeat side, then we can use an asterisk for the index name:
 // each scenario outline will be namespaced, so no collitions between different test cases should appear
-func (mts *MetricbeatTestSuite) setIndexName(version string) {
-	mts.Version = version
-
+func (mts *MetricbeatTestSuite) setIndexName() {
 	mVersion := strings.ReplaceAll(mts.Version, "-SNAPSHOT", "")
 
 	index := fmt.Sprintf("metricbeat-%s-%s-%s", mVersion, mts.ServiceName, mts.ServiceVersion)
@@ -88,7 +86,8 @@ func (mts *MetricbeatTestSuite) installedAndConfiguredForModule(version string, 
 	serviceType = strings.ToLower(serviceType)
 
 	// at this point we have everything to define the index name
-	mts.setIndexName(version)
+	mts.Version = version
+	mts.setIndexName()
 
 	err := mts.runMetricbeatService()
 	if err != nil {

--- a/metricbeat-tests/runner_test.go
+++ b/metricbeat-tests/runner_test.go
@@ -55,7 +55,7 @@ func (mts *MetricbeatTestSuite) setIndexName(version string) {
 
 	index := fmt.Sprintf("metricbeat-%s-%s-%s", mVersion, mts.ServiceName, mts.ServiceVersion)
 
-	index += "-test*"
+	index += "-" + strings.ToLower(randomString(8))
 
 	mts.IndexName = index
 }

--- a/metricbeat-tests/test_utils.go
+++ b/metricbeat-tests/test_utils.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"math/rand"
+	"time"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func randomStringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func randomString(length int) string {
+	return randomStringWithCharset(length, charset)
+}


### PR DESCRIPTION
## What does this PR do?
This PR adds the ability to use pseudo-randomised index name for a test suite, storing the index at test suite level.

## Why is it important?
It will allow to execute each test suite in a separated index, so there would be no document collisions from test suite to test suite.