### PR TITLE
Automatically set the tags flags when needed

### DIFF
--- a/metricbeat-tests/Makefile
+++ b/metricbeat-tests/Makefile
@@ -1,11 +1,14 @@
 FEATURE?=
-FLAG?=
 FORMAT?=pretty
 LOG_INCLUDE_TIMESTAMP?=TRUE
 LOG_LEVEL?=INFO
 METRICBEAT_FETCH_TIMEOUT?=20
 QUERY_MAX_ATTEMPTS?=5
 RETRY_TIMEOUT?=3
+
+ifneq ($(FEATURE),)
+FEATURE_FLAG=--tags
+endif
 
 .PHONY: build-binary
 build-binary:
@@ -22,7 +25,7 @@ functional-test:
 	OP_METRICBEAT_FETCH_TIMEOUT=${METRICBEAT_FETCH_TIMEOUT} \
 	OP_QUERY_MAX_ATTEMPTS=${QUERY_MAX_ATTEMPTS} \
 	OP_RETRY_TIMEOUT=${RETRY_TIMEOUT} \
-	godog --format=${FORMAT} ${FLAG} ${FEATURE}
+	godog --format=${FORMAT} ${FEATURE_FLAG} ${FEATURE}
 
 .PHONY: run-elastic-stack
 run-elastic-stack:

--- a/metricbeat-tests/README.md
+++ b/metricbeat-tests/README.md
@@ -206,12 +206,11 @@ $ make functional-tests    # runs the test suite
 You could set up the environment so that it's possible to run one single module. As we are using _tags_ for matching modules, we could tell `make` to run just the tests for redis:
 
 ```shell
-$ LOG_LEVEL=DEBUG FLAG="-t" FEATURE="redis" make functional-test
+$ LOG_LEVEL=DEBUG FEATURE="redis" make functional-test
 ```
 where:
 
 - LOG_LEVEL: sets the default log level in the tool (DEBUG, INFO, WARN, ERROR, FATAL)
-- FLAG: if set as `-t`, it will tell `Godog` to filter by tag.
 - FEATURE: sets the tag to filter by (apache, mysql, redis)
 
 ### Advanced usage


### PR DESCRIPTION
Remove the `FLAG` environment variable used in the Makefile, and
automatically add the `--tags` flag if a feature is specified when
running functional tests.