### PR TITLE
(#52) Add tests for vSphere

### DIFF
--- a/cli/config/compose/services/vsphere.yml
+++ b/cli/config/compose/services/vsphere.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  vsphere:
+    image: "nimmis/vcsim:${vsphereTag}"
+    container_name: vsphere
+    healthcheck:
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://vsphere:443/"]
+      retries: 10
+      interval: 10s

--- a/metricbeat-tests/configurations/vsphere.yml
+++ b/metricbeat-tests/configurations/vsphere.yml
@@ -1,9 +1,3 @@
-metricbeat.config:
-  modules:
-    path: ${path.config}/modules.d/*.yml
-    # Reload module configs as they change:
-    reload.enabled: false
-
 metricbeat.modules:
   - module: vsphere
     metricsets:

--- a/metricbeat-tests/configurations/vsphere.yml
+++ b/metricbeat-tests/configurations/vsphere.yml
@@ -1,0 +1,18 @@
+metricbeat.config:
+  modules:
+    path: ${path.config}/modules.d/*.yml
+    # Reload module configs as they change:
+    reload.enabled: false
+
+metricbeat.modules:
+  - module: vsphere
+    metricsets:
+      - datastore
+      - host
+      - virtualmachine
+    enabled: true
+    period: 5s
+    hosts: ["https://vsphere:443/sdk"]
+    username: "user"
+    password: "pass"
+    insecure: true

--- a/metricbeat-tests/features/vsphere.feature
+++ b/metricbeat-tests/features/vsphere.feature
@@ -1,0 +1,11 @@
+@vsphere
+Feature: As a Metricbeat developer I want to check that the vSphere module works as expected
+
+Scenario Outline: Check module is sending metrics to Elasticsearch
+  Given vSphere "<vsphere_version>" is running for metricbeat "<metricbeat_version>"
+    And metricbeat "<metricbeat_version>" is installed and configured for vSphere module
+  Then there are no errors in the index
+Examples:
+| vsphere_version | metricbeat_version |
+| latest  | 7.3.0 |
+| latest  | 8.0.0-SNAPSHOT |


### PR DESCRIPTION
## What does this PR do?
This PR adds vSphere to the list of services that could be used to run end-to-end tests. We decided to add it as an example of how easy is the addition of a new integration, without adding no code, just configuration.

## Why is it important?
It's important to start adding services to the POC, so that we can convert the POC into a real tool. Covering more services follows that path.

## Special considerations
When running the tests, and because of the nature of the Docker image for vSphere, which takes too long to start up, we need to instrument test execution to wait for it longer. The test tool supports modifying default timeout via an environment variable.

- `OP_QUERY_MAX_ATTEMPTS`: number of attempts for a elasticsearch query
- `OP_RETRY_TIMEOUT`: seconds between each attempt
- `OP_METRICBEAT_FETCH_TIMEOUT`: seconds that metricbeat will be grabbing metrics from the system

```shell
$ OP_METRICBEAT_FETCH_TIMEOUT=60 OP_QUERY_MAX_ATTEMPTS=20 godog -t vsphere
```

## Related Issues
Closes #52 

## Author's checklist
- [x] vSphere configuration file checked by Beats team
- [x] Tests for vSphere ran and passing locally