### PR TITLE
57 read stack from environment

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -31,6 +31,7 @@ func init() {
 	for k, stack := range config.AvailableStacks() {
 		stackSubcommand := buildRunStackCommand(k, stack)
 
+		stackSubcommand.Flags().StringVarP(&versionToRun, "stackVersion", "v", "latest", "Sets the stack version to run")
 		stackSubcommand.Flags().StringVarP(&servicesToRun, "withServices", "s", "", "Sets a list of comma-separated services to be depoyed alongside the stack")
 
 		runStackCmd.AddCommand(stackSubcommand)
@@ -78,7 +79,11 @@ func buildRunStackCommand(key string, stack config.Stack) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			serviceManager := services.NewServiceManager()
 
-			err := serviceManager.RunCompose(true, []string{key}, map[string]string{})
+			env := map[string]string{
+				"stackVersion": versionToRun,
+			}
+
+			err := serviceManager.RunCompose(true, []string{key}, env)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"stack": key,
@@ -86,7 +91,7 @@ func buildRunStackCommand(key string, stack config.Stack) *cobra.Command {
 			}
 
 			composeNames := []string{}
-			env := map[string]string{}
+			env = map[string]string{}
 			if servicesToRun != "" {
 				services := strings.Split(servicesToRun, ",")
 

--- a/cli/config/compose/stacks/metricbeat.yml
+++ b/cli/config/compose/stacks/metricbeat.yml
@@ -9,7 +9,7 @@ services:
       - xpack.monitoring.collection.enabled=true
       - ELASTIC_USERNAME=elastic
       - ELASTIC_PASSWORD=p4ssw0rd
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.3.0"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:${stackVersion}"
     ports:
       - "9200:9200"
   kibana:
@@ -17,6 +17,6 @@ services:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       - ELASTIC_USERNAME=elastic
       - ELASTIC_PASSWORD=p4ssw0rd
-    image: "docker.elastic.co/kibana/kibana:7.3.0"
+    image: "docker.elastic.co/kibana/kibana:${stackVersion}"
     ports:
       - "5601:5601"

--- a/metricbeat-tests/features/apache.feature
+++ b/metricbeat-tests/features/apache.feature
@@ -2,13 +2,11 @@
 Feature: As a Metricbeat developer I want to check that the Apache module works as expected
 
 Scenario Outline: Check module is sending metrics to Elasticsearch without errors
-  Given Apache "<apache_version>" is running for metricbeat "<metricbeat_version>"
-    And metricbeat "<metricbeat_version>" is installed and configured for Apache module
+  Given Apache "<apache_version>" is running for metricbeat
+    And metricbeat is installed and configured for Apache module
   Then there are "Apache" events in the index
     And there are no errors in the index
 Examples:
-| apache_version | metricbeat_version |
-| 2.2  | 7.3.0 |
-| 2.2  | 8.0.0-SNAPSHOT |
-| 2.4  | 7.3.0 |
-| 2.4  | 8.0.0-SNAPSHOT |
+| apache_version |
+| 2.2            |
+| 2.4            |

--- a/metricbeat-tests/features/metricbeat.feature
+++ b/metricbeat-tests/features/metricbeat.feature
@@ -2,17 +2,11 @@
 Feature: As a Metricbeat developer I want to check that default configuration works as expected
 
 Scenario Outline: Check <configuration> configuration is sending metrics to Elasticsearch without errors
-  Given metricbeat "<metricbeat_version>" is installed using "<configuration>" configuration
+  Given metricbeat is installed using "<configuration>" configuration
   Then there are "system" events in the index
     And there are no errors in the index
 Examples:
-| metricbeat_version | configuration        |
-| 7.3.0              | metricbeat           |
-| 7.4.0              | metricbeat           |
-| 8.0.0-SNAPSHOT     | metricbeat           |
-| 7.3.0              | metricbeat.docker    | 
-| 7.4.0              | metricbeat.docker    |
-| 8.0.0-SNAPSHOT     | metricbeat.docker    |
-| 7.3.0              | metricbeat.reference | 
-| 7.4.0              | metricbeat.reference |
-| 8.0.0-SNAPSHOT     | metricbeat.reference |
+| configuration        |
+| metricbeat           |
+| metricbeat.docker    |
+| metricbeat.reference |

--- a/metricbeat-tests/features/mysql.feature
+++ b/metricbeat-tests/features/mysql.feature
@@ -2,15 +2,12 @@
 Feature: As a Metricbeat developer I want to check that the MySQL module works as expected
 
 Scenario Outline: Check module is sending metrics to Elasticsearch without errors
-  Given MySQL "<mysql_version>" is running for metricbeat "<metricbeat_version>"
-    And metricbeat "<metricbeat_version>" is installed and configured for MySQL module
+  Given MySQL "<mysql_version>" is running for metricbeat
+    And metricbeat is installed and configured for MySQL module
   Then there are "MySQL" events in the index
     And there are no errors in the index
 Examples:
-| mysql_version | metricbeat_version |
-| 5.6  | 7.3.0 |
-| 5.7  | 7.3.0 |
-| 8.0  | 7.3.0 |
-| 5.6  | 8.0.0-SNAPSHOT |
-| 5.7  | 8.0.0-SNAPSHOT |
-| 8.0  | 8.0.0-SNAPSHOT |
+| mysql_version |
+| 5.6           |
+| 5.7           |
+| 8.0           |

--- a/metricbeat-tests/features/redis.feature
+++ b/metricbeat-tests/features/redis.feature
@@ -2,13 +2,11 @@
 Feature: As a Metricbeat developer I want to check that the Redis module works as expected
 
 Scenario Outline: Check module is sending metrics to Elasticsearch without errors
-  Given Redis "<redis_version>" is running for metricbeat "<metricbeat_version>"
-    And metricbeat "<metricbeat_version>" is installed and configured for Redis module
+  Given Redis "<redis_version>" is running for metricbeat
+    And metricbeat is installed and configured for Redis module
   Then there are "Redis" events in the index
     And there are no errors in the index
 Examples:
-| redis_version | metricbeat_version |
-| 4.0.14  | 7.3.0 |
-| 4.0.14  | 8.0.0-SNAPSHOT |
-| 5.0.5  | 7.3.0 |
-| 5.0.5  | 8.0.0-SNAPSHOT |
+| redis_version |
+| 4.0.14        |
+| 5.0.5         |

--- a/metricbeat-tests/features/vsphere.feature
+++ b/metricbeat-tests/features/vsphere.feature
@@ -2,11 +2,10 @@
 Feature: As a Metricbeat developer I want to check that the vSphere module works as expected
 
 Scenario Outline: Check module is sending metrics to Elasticsearch without errors
-  Given vSphere "<vsphere_version>" is running for metricbeat "<metricbeat_version>"
-    And metricbeat "<metricbeat_version>" is installed and configured for vSphere module
+  Given vSphere "<vsphere_version>" is running for metricbeat
+    And metricbeat is installed and configured for vSphere module
   Then there are "vSphere" events in the index
     And there are no errors in the index
 Examples:
-| vsphere_version | metricbeat_version |
-| latest  | 7.3.0 |
-| latest  | 8.0.0-SNAPSHOT |
+| vsphere_version |
+| latest          |

--- a/metricbeat-tests/service_common_test.go
+++ b/metricbeat-tests/service_common_test.go
@@ -8,12 +8,12 @@ import (
 func FeatureContext(s *godog.Suite) {
 	testSuite := MetricbeatTestSuite{}
 
-	s.Step(`^([^"]*) "([^"]*)" is running for metricbeat "([^"]*)"$`, testSuite.serviceIsRunningForMetricbeat)
-	s.Step(`^metricbeat "([^"]*)" is installed and configured for ([^"]*) module$`, testSuite.installedAndConfiguredForModule)
+	s.Step(`^([^"]*) "([^"]*)" is running for metricbeat$`, testSuite.serviceIsRunningForMetricbeat)
+	s.Step(`^metricbeat is installed and configured for ([^"]*) module$`, testSuite.installedAndConfiguredForModule)
 	s.Step(`^there are no errors in the index$`, testSuite.thereAreNoErrorsInTheIndex)
 	s.Step(`^there are "([^"]*)" events in the index$`, testSuite.thereAreEventsInTheIndex)
 
-	s.Step(`^metricbeat "([^"]*)" is installed using "([^"]*)" configuration$`, testSuite.installedUsingConfiguration)
+	s.Step(`^metricbeat is installed using "([^"]*)" configuration$`, testSuite.installedUsingConfiguration)
 
 	s.BeforeScenario(func(interface{}) {
 		log.Debug("Before scenario...")


### PR DESCRIPTION
## What does this PR do?
It adds the ability to run a Elastic stack with a specific version, using a flag in the CLI side of this tool.

Besides that, we are simplifying the test framework, moving the version matrix for metricbeat and elastic stack to the automation tool (local or on CI). We will read the metricbeat version from an environment variable (`OP_METRICBEAT_VERSION`).

## Why is it important?
It will allow iterating faster, as the test framework will just run tests for one single version of the stack and metricbeat. It will be a responsibility of the automation tool to define the values used for metricbeat and the stack.