### PR TITLE
Support executing one-shot script for functional tests

### DIFF
--- a/.ci/functionalTests.groovy
+++ b/.ci/functionalTests.groovy
@@ -100,7 +100,7 @@ pipeline {
       environment {
         GO111MODULE = 'on'
         GOROOT = "${env.WORKSPACE}/.gimme/versions/go${env.GO_VERSION}.linux.amd64"
-        PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.GOROOT}/bin:${env.GOPATH}/bin:${env.PATH}"
+        PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.GOROOT}/bin:${env.GOPATH}/bin:${HOME}/go/bin:${env.PATH}"
         GOPROXY = 'https://proxy.golang.org'
         STACK_VERSION = "${params.STACK_VERSION}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION}"

--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -11,6 +11,8 @@ set -euxo pipefail
 
 GO_VERSION=${1:?GO_VERSION is not set}
 FEATURE=${2:-''}
+STACK_VERSION=${3:-'7.5.0'}
+METRICBEAT_VERSION=${4:-'7.5.0'}
 
 # shellcheck disable=SC1091
 source .ci/scripts/install-go.sh "${GO_VERSION}"
@@ -19,7 +21,7 @@ source .ci/scripts/install-go.sh "${GO_VERSION}"
 make -C metricbeat-tests build-binary
 
 # Build runtime dependencies
-make -C metricbeat-tests run-elastic-stack
+STACK_VERSION=${STACK_VERSION} make -C metricbeat-tests run-elastic-stack
 
 rm -rf outputs || true
 mkdir -p outputs
@@ -36,7 +38,7 @@ fi
 ## Generate test report even if make failed.
 set +e
 exit_status=0
-if ! FLAG=${FLAG} FEATURE=${FEATURE} FORMAT=junit make -C metricbeat-tests functional-test | tee ${REPORT}  ; then
+if ! FLAG=${FLAG} FEATURE=${FEATURE} FORMAT=junit STACK_VERSION=${STACK_VERSION} METRICBEAT_VERSION=${METRICBEAT_VERSION} make -C metricbeat-tests functional-test | tee ${REPORT}  ; then
   echo 'ERROR: functional-test failed'
   exit_status=1
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin
+outputs

--- a/metricbeat-tests/README.md
+++ b/metricbeat-tests/README.md
@@ -92,13 +92,26 @@ There will exist a configuration YAML file per module, under the `configurations
 At this moment, the CLI and the functional tests coexist in the same repository, that's why we are building the CLI to get access to its features. Eventually that would change and we would consume it as a binary. Meanwhile, execute this from the ROOT directory of this project:
 
 ```shell
+$ export GO111MODULE=on                            # Go modules support
+$ make -C cli install                              # installs CLI dependencies
 $ export STACK_VERSION=7.5.0                       # exports stack version as runtime
 $ export METRICBEAT_VERSION=7.5.0                  # exports metricbeat version to be tested
 $ # export FEATURE=redis                           # exports which feature to run (default 'all')
+$ make -C metricbeat-tests install                 # installs tests dependencies
 $ make -C metricbeat-tests build-binary            # generates the binary from the repository
 $ make -C metricbeat-tests run-elastic-stack       # runs the stack for metricbeat
 $ make -C metricbeat-tests functional-test         # runs the test suite for Redis and stack 
 $ make -C metricbeat-tests shutdown-elastic-stack  # stops the stack
+```
+
+or simply run as the CI does:
+
+```shell
+$ export GO_VERSION=1.12.7                         # exports which GIMME version to use
+$ export STACK_VERSION=7.5.0                       # exports stack version as runtime
+$ export METRICBEAT_VERSION=7.5.0                  # exports metricbeat version
+$ #export FEATURE=redis                            # exports which feature to run (default 'all')
+$ ./.ci/scripts/functional-test.sh ${GO_VERSION} ${FEATURE}
 ```
 
 You could set up the environment so that it's possible to run one single module. As we are using _tags_ for matching modules, we could tell `make` to run just the tests for redis:


### PR DESCRIPTION
## What does this PR do?
It adds support to passing stack and metricbeat versions when running the `functional-tests.sh` script.

## Why is this important?
It simplifies test execution, doing as the CI does