### PR TITLE
Fix paths

### DIFF
--- a/.ci/functionalTests.groovy
+++ b/.ci/functionalTests.groovy
@@ -99,8 +99,7 @@ pipeline {
       options { skipDefaultCheckout() }
       environment {
         GO111MODULE = 'on'
-        GOROOT = "${env.WORKSPACE}/.gimme/versions/go${env.GO_VERSION}.linux.amd64"
-        PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.GOROOT}/bin:${env.GOPATH}/bin:${HOME}/go/bin:${env.PATH}"
+        PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.GOPATH}/bin:${HOME}/go/bin:${env.PATH}"
         GOPROXY = 'https://proxy.golang.org'
         STACK_VERSION = "${params.STACK_VERSION}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION}"

--- a/metricbeat-tests/go.mod
+++ b/metricbeat-tests/go.mod
@@ -13,3 +13,5 @@ require (
 )
 
 replace github.com/testcontainers/testcontainers-go v0.0.8 => github.com/mdelapenya/testcontainers-go v0.0.9-compose
+
+replace github.com/elastic/metricbeat-tests-poc/cli v0.1.0-rc6 => ../cli


### PR DESCRIPTION
## What does this PR do?
It cleans up the GO environment variables in the pipeline, removing the GOROOT one.

Besides, it replaces the external dependency on CLI, as they live in the same repository