### PR TITLE
Do not use the network when fetching Go dependencies

### DIFF
--- a/.ci/scripts/install-dependencies.sh
+++ b/.ci/scripts/install-dependencies.sh
@@ -17,10 +17,10 @@ GOPROXY_CONTEXT=${GOPROXY}
 GOPROXY=''
 
 # Install some other dependencies required for the pre-commit
-go get -v -u golang.org/x/lint/golint
-go get -v -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
-go get -v -u github.com/go-lintpack/lintpack/...
-go get -v -u github.com/go-critic/go-critic/...
+go get -v golang.org/x/lint/golint
+go get -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+go get -v github.com/go-lintpack/lintpack/...
+go get -v github.com/go-critic/go-critic/...
 lintpack build -o bin/gocritic -linter.version='v0.3.4' -linter.name='gocritic' github.com/go-critic/go-critic/checkers
 
 # enable GOPROXY


### PR DESCRIPTION
## What is this PR doing?
A dependency started to fail on CI and we enabled not using the network when fetching it.

From `go get` docs:

>The -u flag instructs get to use the network to update the named packages
and their dependencies. By default, get uses the network to check out
missing packages but does not use it to look for updates to existing packages

## Why is it important?
CI was not able to get dependencies, failing before any test execution