### PR TITLE
Use versions from integrations-ci

### DIFF
--- a/cli/config/compose/services/apache.yml
+++ b/cli/config/compose/services/apache.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   apache:
-    image: "docker.elastic.co/integrations-ci/beats-apache:${apacheTag}"
+    image: "docker.elastic.co/integrations-ci/beats-apache:${apacheTag}-1"
     ports:
       - "80:80"

--- a/cli/config/compose/services/apache.yml
+++ b/cli/config/compose/services/apache.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   apache:
-    image: "docker.elastic.co/observability-ci/apache:${apacheTag}"
+    image: "docker.elastic.co/integrations-ci/beats-apache:${apacheTag}"
     ports:
       - "80:80"

--- a/cli/config/compose/services/kafka.yml
+++ b/cli/config/compose/services/kafka.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   kafka:
-    image: "wurstmeister/kafka:${kafkaTag}"
+    image: "docker.elastic.co/integrations-ci/beats-kafka:${kafkaTag}"
     ports:
       - "9092:9092"

--- a/cli/config/compose/services/kafka.yml
+++ b/cli/config/compose/services/kafka.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   kafka:
-    image: "docker.elastic.co/integrations-ci/beats-kafka:${kafkaTag}"
+    image: "docker.elastic.co/integrations-ci/beats-kafka:${kafkaTag}-2"
     ports:
       - "9092:9092"

--- a/cli/config/compose/services/mysql.yml
+++ b/cli/config/compose/services/mysql.yml
@@ -3,6 +3,6 @@ services:
   mysql:
     environment:
       - MYSQL_ROOT_PASSWORD=secret
-    image: "docker.elastic.co/observability-ci/mysql:${mysqlTag}"
+    image: "docker.elastic.co/integrations-ci/beats-mysql:${mysqlTag}"
     ports:
       - "3306:3306"

--- a/cli/config/compose/services/mysql.yml
+++ b/cli/config/compose/services/mysql.yml
@@ -3,6 +3,6 @@ services:
   mysql:
     environment:
       - MYSQL_ROOT_PASSWORD=secret
-    image: "docker.elastic.co/integrations-ci/beats-mysql:${mysqlTag}"
+    image: "docker.elastic.co/integrations-ci/beats-mysql:${mysqlTag}-1"
     ports:
       - "3306:3306"

--- a/cli/config/compose/services/redis.yml
+++ b/cli/config/compose/services/redis.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   redis:
-    image: "redis:${redisTag}"
+    image: "docker.elastic.co/integrations-ci/beats-redis:${redisTag}"
     ports:
       - "6379:6379"

--- a/cli/config/compose/services/redis.yml
+++ b/cli/config/compose/services/redis.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   redis:
-    image: "docker.elastic.co/integrations-ci/beats-redis:${redisTag}"
+    image: "docker.elastic.co/integrations-ci/beats-redis:${redisTag}-1"
     ports:
       - "6379:6379"

--- a/metricbeat-tests/features/apache.feature
+++ b/metricbeat-tests/features/apache.feature
@@ -10,5 +10,5 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
     And there are no errors in the index
 Examples:
 | apache_version |
-| 2.4.12         |
-| 2.4.20         |
+| 2.4.12-1       |
+| 2.4.20-1       |

--- a/metricbeat-tests/features/apache.feature
+++ b/metricbeat-tests/features/apache.feature
@@ -10,5 +10,5 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
     And there are no errors in the index
 Examples:
 | apache_version |
-| 2.4.12-1       |
-| 2.4.20-1       |
+| 2.4.12         |
+| 2.4.20         |

--- a/metricbeat-tests/features/mysql.feature
+++ b/metricbeat-tests/features/mysql.feature
@@ -6,9 +6,14 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
     And metricbeat is installed and configured for MySQL module
     And metricbeat waits "20" seconds for the service
   When metricbeat runs for "20" seconds
-  Then there are "MySQL" events in the index
+  Then there are "<variant>" events in the index
     And there are no errors in the index
 Examples:
-| mysql_version  |
-| mysql-5.7.12-1 |
-| mysql-8.0.13-1 |
+| mysql_version      | variant |
+| mariadb-10.2.23-1  | MariaDB |
+| mariadb-10.3.14-1  | MariaDB |
+| mariadb-10.4.4-1   | MariaDB |
+| mysql-5.7.12-1     | MySQL   |
+| mysql-8.0.13-1     | MySQL   |
+| percona-5.7.24-1   | Percona |
+| percona-8.0.13-4-1 | Percona |

--- a/metricbeat-tests/features/mysql.feature
+++ b/metricbeat-tests/features/mysql.feature
@@ -9,7 +9,6 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
   Then there are "MySQL" events in the index
     And there are no errors in the index
 Examples:
-| mysql_version |
-| 5.7.12        |
-| 5.7.24        |
-| 8.0.13        |
+| mysql_version  |
+| mysql-5.7.12-1 |
+| mysql-8.0.13-1 |

--- a/metricbeat-tests/features/mysql.feature
+++ b/metricbeat-tests/features/mysql.feature
@@ -10,10 +10,10 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
     And there are no errors in the index
 Examples:
 | mysql_version      | variant |
-| mariadb-10.2.23-1  | MariaDB |
-| mariadb-10.3.14-1  | MariaDB |
-| mariadb-10.4.4-1   | MariaDB |
-| mysql-5.7.12-1     | MySQL   |
-| mysql-8.0.13-1     | MySQL   |
-| percona-5.7.24-1   | Percona |
-| percona-8.0.13-4-1 | Percona |
+| mariadb-10.2.23    | MariaDB |
+| mariadb-10.3.14    | MariaDB |
+| mariadb-10.4.4     | MariaDB |
+| mysql-5.7.12       | MySQL   |
+| mysql-8.0.13       | MySQL   |
+| percona-5.7.24     | Percona |
+| percona-8.0.13-4   | Percona |

--- a/metricbeat-tests/features/redis.feature
+++ b/metricbeat-tests/features/redis.feature
@@ -10,6 +10,6 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
     And there are no errors in the index
 Examples:
 | redis_version |
-| 3.2.12-1      |
-| 4.0.11-1      |
-| 5.0.5-1       |
+| 3.2.12        |
+| 4.0.11        |
+| 5.0.5         |

--- a/metricbeat-tests/features/redis.feature
+++ b/metricbeat-tests/features/redis.feature
@@ -10,5 +10,6 @@ Scenario Outline: Check module is sending metrics to Elasticsearch without error
     And there are no errors in the index
 Examples:
 | redis_version |
-| 4.0.14        |
-| 5.0.5         |
+| 3.2.12-1      |
+| 4.0.11-1      |
+| 5.0.5-1       |


### PR DESCRIPTION
## What does this PR do?
It uses `integrations-ci` Docker registry in the integrations supported by this PoC.

Besides that, it adds the proper versions of those integrations, as seen in this Jenkins build: https://apm-ci.elastic.co/blue/organizations/jenkins/beats%2Fbeats-docker-images-pipeline/detail/beats-docker-images-pipeline/84/pipeline/58

## Why is it important?
We will be using the same images than those used in Beats development, so we will be testing the same.

## Author's checklist
- [x] Run mysql, redis, apache and vsphere tests in isolation and they pass
- [x] Run the entire test suite and it passes

## Related Issues
- Closes #80
- Closes #81