### PR TITLE
feat: Support removing certain blocks from Beats Integrations compose files

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -196,7 +196,6 @@ func sanitizeComposeFile(composeFilePath string) error {
 	if err != nil {
 		return err
 	}
-	io.WriteFile(d, composeFilePath)
 
-	return nil
+	return io.WriteFile(d, composeFilePath)
 }

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -112,15 +112,22 @@ func copyIntegrationsComposeFiles(beats git.Project, target string) {
 		targetFile := filepath.Join(
 			target, "compose", "services", service, "docker-compose.yml")
 
-		// discard error in any case
-		_ = io.MkdirAll(filepath.Dir(targetFile))
-
-		err := io.CopyFile(composeFile, targetFile, 10000)
+		err := io.MkdirAll(filepath.Dir(targetFile))
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
 				"file":  file,
 			}).Warn("File was not copied")
+			continue
+		}
+
+		err = io.CopyFile(composeFile, targetFile, 10000)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+				"file":  file,
+			}).Warn("File was not copied")
+			continue
 		}
 
 		targetMetaDir := filepath.Join(target, "compose", "services", service, "_meta")
@@ -130,11 +137,16 @@ func copyIntegrationsComposeFiles(beats git.Project, target string) {
 				"error": err,
 				"_meta": metaDir,
 			}).Warn("Meta dir was not copied")
+			continue
 		}
 
 		err = sanitizeComposeFile(targetFile)
 		if err != nil {
-			log.Fatalf("error: %v", err)
+			log.WithFields(log.Fields{
+				"error": err,
+				"file":  targetFile,
+			}).Warn("Could not sanitize compose file")
+			continue
 		}
 	}
 }

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -18,6 +18,7 @@ import (
 )
 
 var deleteRepository = false
+var excludedBlocks = []string{"build"}
 var remote = "elastic:master"
 
 func init() {
@@ -78,6 +79,16 @@ var syncIntegrationsCmd = &cobra.Command{
 
 		copyIntegrationsComposeFiles(BeatsRepo, workspace)
 	},
+}
+
+// tells whether the a array contains the x string.
+func contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
 }
 
 // CopyComposeFiles copies only those services that has a supported-versions.yml
@@ -168,7 +179,7 @@ func sanitizeComposeFile(composeFilePath string) error {
 				strKey := fmt.Sprintf("%v", key)
 
 				// remove the build context element
-				if key == "build" {
+				if contains(excludedBlocks, strKey) {
 					continue
 				}
 

--- a/cli/internal/io.go
+++ b/cli/internal/io.go
@@ -195,7 +195,7 @@ func WriteFile(bytes []byte, target string) error {
 		log.WithFields(log.Fields{
 			"target": target,
 			"error":  err,
-		}).Error("Cannot write file at workdir.")
+		}).Error("Cannot write file")
 
 		return err
 	}

--- a/cli/internal/io.go
+++ b/cli/internal/io.go
@@ -93,7 +93,7 @@ func CopyFile(src string, dst string, bufferSize int64) error {
 		// always override
 	}
 
-	err = MkdirAll(dst)
+	err = MkdirAll(filepath.Dir(dst))
 	if err != nil {
 		return err
 	}

--- a/cli/internal/io.go
+++ b/cli/internal/io.go
@@ -11,8 +11,8 @@ import (
 )
 
 // CopyDir recursively copies a directory tree, attempting to preserve permissions.
-// Source directory must exist, destination directory must *not* exist.
-// Symlinks are ignored and skipped.
+// Source directory must exist, destination directory will be overridden if it
+// exists. Symlinks are ignored and skipped.
 func CopyDir(src string, dst string) error {
 	src = filepath.Clean(src)
 	dst = filepath.Clean(dst)
@@ -30,7 +30,7 @@ func CopyDir(src string, dst string) error {
 		return err
 	}
 	if err == nil {
-		return errors.New("destination already exists")
+		// always override
 	}
 
 	err = MkdirAll(dst)
@@ -68,7 +68,8 @@ func CopyDir(src string, dst string) error {
 	return nil
 }
 
-// CopyFile copies a file from a source to a destiny
+// CopyFile copies a file from a source to a destiny, always overridding
+// the destination file
 // Optimising the copy of files in Go:
 // https://opensource.com/article/18/6/copying-files-go
 func CopyFile(src string, dst string, bufferSize int64) error {
@@ -89,7 +90,7 @@ func CopyFile(src string, dst string, bufferSize int64) error {
 
 	_, err = os.Stat(dst)
 	if err == nil {
-		return errors.New("File " + dst + " already exists")
+		// always override
 	}
 
 	err = MkdirAll(dst)

--- a/cli/internal/io.go
+++ b/cli/internal/io.go
@@ -29,9 +29,7 @@ func CopyDir(src string, dst string) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if err == nil {
-		// always override
-	}
+	// always override
 
 	err = MkdirAll(dst)
 	if err != nil {
@@ -89,9 +87,7 @@ func CopyFile(src string, dst string, bufferSize int64) error {
 	defer source.Close()
 
 	_, err = os.Stat(dst)
-	if err == nil {
-		// always override
-	}
+	// always override
 
 	err = MkdirAll(filepath.Dir(dst))
 	if err != nil {

--- a/cli/internal/io.go
+++ b/cli/internal/io.go
@@ -86,7 +86,6 @@ func CopyFile(src string, dst string, bufferSize int64) error {
 	}
 	defer source.Close()
 
-	_, _ = os.Stat(dst)
 	// always override
 
 	err = MkdirAll(filepath.Dir(dst))

--- a/cli/internal/io.go
+++ b/cli/internal/io.go
@@ -86,7 +86,7 @@ func CopyFile(src string, dst string, bufferSize int64) error {
 	}
 	defer source.Close()
 
-	_, err = os.Stat(dst)
+	_, _ = os.Stat(dst)
 	// always override
 
 	err = MkdirAll(filepath.Dir(dst))

--- a/cli/internal/state.go
+++ b/cli/internal/state.go
@@ -100,7 +100,12 @@ func Update(id string, workdir string, composeFilePaths []string, env map[string
 		}).Error("Could not marshal state")
 	}
 
-	WriteFile(bytes, stateFile) //nolint
+	err = WriteFile(bytes, stateFile) //nolint
+	if err != nil {
+		log.WithFields(log.Fields{
+			"stateFile": stateFile,
+		}).Error("Could not create state file")
+	}
 
 	log.WithFields(log.Fields{
 		"dir":       workdir,

--- a/cli/internal/state.go
+++ b/cli/internal/state.go
@@ -67,6 +67,13 @@ func Destroy(id string, workdir string) {
 // The state file will be located under 'workdir', which by default will be the tool's
 // workspace.
 func Update(id string, workdir string, composeFilePaths []string, env map[string]string) {
+	stateFile := filepath.Join(workdir, id+".run")
+
+	log.WithFields(log.Fields{
+		"dir":       workdir,
+		"stateFile": stateFile,
+	}).Debug("Updating state")
+
 	run := stateRun{
 		ID:       id,
 		Env:      env,
@@ -91,8 +98,6 @@ func Update(id string, workdir string, composeFilePaths []string, env map[string
 	}
 	args = append(args, "config")
 
-	stateFile := filepath.Join(workdir, id+".run")
-
 	bytes, err := yaml.Marshal(&run)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -110,5 +115,5 @@ func Update(id string, workdir string, composeFilePaths []string, env map[string
 	log.WithFields(log.Fields{
 		"dir":       workdir,
 		"stateFile": stateFile,
-	}).Debug("Updating state")
+	}).Debug("State updated")
 }


### PR DESCRIPTION
## What does this PR do?
It adds a method to sanitize the compose files that come from the Beats repo, removing the `build` section under any service.

Besides that, we fixed an issue that affected the creation of parent directories when copying files, also overridding the files and directories in this process.

## Why is it important?
The Integrations compose files come with a `build` section, because it's used in there to build the images, but we do not want to use that feature, as it forces the docker-compose commands to have access to the the file system paths that are present in the `build.context` block.

We proposed those paths to be configurables (https://github.com/elastic/beats/pull/16311), but we realised it's better/easier to remove them for our internal purpose.

## Related issues
- Superseds https://github.com/elastic/beats/pull/16311
- Closes #87