### PR TITLE
fix: make sure parallel release stages have Go installed

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -125,7 +125,7 @@ def generateStep(Map params = [:]){
         deleteDir()
         unstash 'build'
         dir("${BASE_DIR}") {
-          sh script: """.ci/scripts/install-go.sh "${GO_VERSION}" """, label: 'Install Go'
+          sh script: ".ci/scripts/install-go.sh '${GO_VERSION}' ", label: 'Install Go'
         }
         dir("${BASE_DIR}/cli") {
           withEnv(["GOOS=${oss}", "GOARCH=${platform}"]) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -124,6 +124,9 @@ def generateStep(Map params = [:]){
       try {
         deleteDir()
         unstash 'build'
+        dir("${BASE_DIR}") {
+          sh script: """.ci/scripts/install-go.sh "${GO_VERSION}" """, label: 'Install Go'
+        }
         dir("${BASE_DIR}/cli") {
           withEnv(["GOOS=${oss}", "GOARCH=${platform}"]) {
             sh script: 'make build', label: 'Create releases'


### PR DESCRIPTION
## What does this PR do?
It installs Go in the each linux machine used for releasing each supported platform

## Why is it important?
If Go is not installed in the workers, then the Go build command will fail 🤷‍♂ 

See https://apm-ci.elastic.co/blue/organizations/jenkins/beats%2Fpoc-metricbeat-tests-poc-mbp/detail/v0.1.0-rc9/1/pipeline

## Related issues
- Closes #46