### PR TITLE
fix: set proper Go environment on release

### DIFF
--- a/.ci/.package.yaml
+++ b/.ci/.package.yaml
@@ -2,7 +2,6 @@
 OSS:
   - "darwin"
   - "linux"
-  - "windows"
 
 PLATFORM:
   - "386"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -88,10 +88,6 @@ pipeline {
         }
         stage('Release') {
           options { skipDefaultCheckout() }
-          environment {
-            GOROOT = "${env.WORKSPACE}/.gimme/versions/go${env.GO_VERSION}.linux.amd64"
-            PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.PATH}:${env.GOROOT}/bin"
-          }
           when { tag "v*" }
           steps {
             deleteDir()
@@ -128,9 +124,6 @@ def generateStep(Map params = [:]){
       try {
         deleteDir()
         unstash 'build'
-        dir("${BASE_DIR}") {
-          sh script: ".ci/scripts/install-go.sh '${GO_VERSION}' ", label: 'Install Go'
-        }
         dir("${BASE_DIR}/cli") {
           withEnv(["GOOS=${oss}", "GOARCH=${platform}"]) {
             sh script: 'make build', label: 'Create releases'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -88,6 +88,10 @@ pipeline {
         }
         stage('Release') {
           options { skipDefaultCheckout() }
+          environment {
+            GOROOT = "${env.WORKSPACE}/.gimme/versions/go${env.GO_VERSION}.linux.amd64"
+            PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.PATH}:${env.GOROOT}/bin"
+          }
           when { tag "v*" }
           steps {
             deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
-    string(name: 'GO_VERSION', defaultValue: '1.12.7', description: "Go version to use.")
+    string(name: 'GO_VERSION', defaultValue: '1.13.4', description: "Go version to use.")
   }
   stages {
     stage('Initializing'){

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,8 +1,19 @@
 TEST_TIMEOUT?=5m
 
+GO_IMAGE?='golang'
+GO_VERSION?='1.13'
+GO_IMAGE_TAG?='stretch'
+GOOS?='linux'
+GOARCH?='amd64'
+
 .PHONY: build
 build:
-	../.ci/scripts/build-cli.sh
+	docker run --rm \
+		-v $(PWD):/go/src/github.com/elastic/metricbeat-tests-poc/cli \
+		-w /go/src/github.com/elastic/metricbeat-tests-poc/cli \
+		-e TARGET_OS=$(GOOS) -e TARGET_ARCH=$(GOARCH) -e GO111MODULE=on \
+		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
+		scripts/build-cli.sh
 
 .PHONY: install
 install:

--- a/cli/scripts/build-cli.sh
+++ b/cli/scripts/build-cli.sh
@@ -4,16 +4,16 @@ set -exo pipefail
 readonly supportedOSS=("darwin" "linux" "windows")
 readonly supportedArchs=("386" "amd64")
 
-arch="${GOARCH}"
+arch="${TARGET_ARCH}"
 extension=""
-goos="${GOOS}"
+goos="${TARGET_OS}"
 separator=""
 
-if [[ "${GOOS}" != "" ]]; then
+if [[ "${TARGET_OS}" != "" ]]; then
     # GO_OS represents the Golang's supported Operative Systems.
     # Possible values: darwin, linux, windows
-    readonly GO_OS="${GOOS:-linux}"
-    if [[ ! " ${supportedOSS[@]} " =~ " ${GOOS} " ]]; then
+    readonly GO_OS="${TARGET_OS:-linux}"
+    if [[ ! " ${supportedOSS[@]} " =~ " ${GO_OS} " ]]; then
         echo "It's not possible to build a binary for ${GO_OS}. Supported values: darwin, linux, windows"
         exit 1
     fi
@@ -24,14 +24,13 @@ if [[ "${GOOS}" != "" ]]; then
         extension=".exe"
     fi
 
-    export GOOS=${GO_OS}
     separator="-"
 fi
 
-if [[ "${GOARCH}" != "" ]]; then
+if [[ "${TARGET_ARCH}" != "" ]]; then
     # GO_ARCH represents the Golang's supported Architectures.
     # Possible values: 386, amd64
-    readonly GO_ARCH="${GOARCH:-amd64}"
+    readonly GO_ARCH="${TARGET_ARCH:-amd64}"
     if [[ ! " ${supportedArchs[@]} " =~ " ${GO_ARCH} " ]]; then
         echo "It's not possible to build a binary for ${GO_ARCH}. Supported values: 386, amd64"
         exit 1
@@ -42,7 +41,6 @@ if [[ "${GOARCH}" != "" ]]; then
         arch="64"
     fi
 
-    export GOARCH=${GO_ARCH}
     separator="-"
 fi
 
@@ -55,7 +53,7 @@ echo ">>> Generating Packr boxes"
 packr2
 
 echo ">>> Building CLI"
-go build -v -o $(pwd)/.github/releases/download/${VERSION}/${goos}${arch}${separator}op${extension}
+GOOS=${GO_OS} GOARCH=${GO_ARCH} go build -v -o $(pwd)/.github/releases/download/${VERSION}/${goos}${arch}${separator}op${extension}
 
 echo ">>> Cleaning up Packr boxes"
 packr2 clean


### PR DESCRIPTION
## What does this PR do?
It builds the CLI inside a Docker container from Makefile.

Besides that, we are removing Windows compilation because of:
>/go/pkg/mod/github.com/docker/docker@v0.7.3-0.20190506211059-b20a14b54661/pkg/system/filesys_windows.go:111:24: cannot use uintptr(unsafe.Pointer(&sd[0])) (type uintptr) as type *"golang.org/x/sys/windows".SECURITY_DESCRIPTOR in assignment

## Why is it important?
Using a Docker container for running tools avoid messing things up with the environment.

## Author's checklist
- [x] Tested with local environment
~~- [ ] Generation of windows binaries failing~~

<img width="1437" alt="Screenshot 2020-02-28 at 11 16 24" src="https://user-images.githubusercontent.com/951580/75540163-cc835f80-5a1b-11ea-8f6b-4680d6651209.png">