### PR TITLE
fix: Functional tests execution in CI

### DIFF
--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -13,12 +13,14 @@ GO_VERSION=${1:?GO_VERSION is not set}
 FEATURE=${2:-''}
 STACK_VERSION=${3:-'7.5.0'}
 METRICBEAT_VERSION=${4:-'7.5.0'}
+TARGET_OS=${GOOS}
+TARGET_ARCH=${GOARCH:-amd64}
 
 # shellcheck disable=SC1091
 source .ci/scripts/install-go.sh "${GO_VERSION}"
 
 # Build OP Binary
-make -C metricbeat-tests fetch-binary
+GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} make -C metricbeat-tests fetch-binary
 
 # Build runtime dependencies
 STACK_VERSION=${STACK_VERSION} make -C metricbeat-tests run-elastic-stack

--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -11,8 +11,8 @@ set -euxo pipefail
 
 GO_VERSION=${1:?GO_VERSION is not set}
 FEATURE=${2:-''}
-STACK_VERSION=${3:-'7.5.0'}
-METRICBEAT_VERSION=${4:-'7.5.0'}
+STACK_VERSION=${3:-'7.6.0'}
+METRICBEAT_VERSION=${4:-'7.6.0'}
 TARGET_OS=${GOOS:-linux}
 TARGET_ARCH=${GOARCH:-amd64}
 

--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -13,7 +13,7 @@ GO_VERSION=${1:?GO_VERSION is not set}
 FEATURE=${2:-''}
 STACK_VERSION=${3:-'7.5.0'}
 METRICBEAT_VERSION=${4:-'7.5.0'}
-TARGET_OS=${GOOS}
+TARGET_OS=${GOOS:-linux}
 TARGET_ARCH=${GOARCH:-amd64}
 
 # shellcheck disable=SC1091

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,3 +1,6 @@
+# Get current directory of a Makefile: https://stackoverflow.com/a/23324703
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
 TEST_TIMEOUT?=5m
 
 GO_IMAGE?='golang'
@@ -9,7 +12,7 @@ GOARCH?='amd64'
 .PHONY: build
 build:
 	docker run --rm \
-		-v $(PWD):/go/src/github.com/elastic/metricbeat-tests-poc/cli \
+		-v $(ROOT_DIR):/go/src/github.com/elastic/metricbeat-tests-poc/cli \
 		-w /go/src/github.com/elastic/metricbeat-tests-poc/cli \
 		-e TARGET_OS=$(GOOS) -e TARGET_ARCH=$(GOARCH) -e GO111MODULE=on \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,5 +1,5 @@
 # Get current directory of a Makefile: https://stackoverflow.com/a/23324703
-ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+ROOT_DIR:=$(CURDIR)
 
 TEST_TIMEOUT?=5m
 

--- a/metricbeat-tests/Makefile
+++ b/metricbeat-tests/Makefile
@@ -12,10 +12,15 @@ ifneq ($(FEATURE),)
 FEATURE_FLAG=--tags
 endif
 
+GO_IMAGE_TAG?='stretch'
+GOOS?='linux'
+GOARCH?='amd64'
+
 .PHONY: fetch-binary
 fetch-binary:
 	@$(MAKE) -C ../cli build
-	cp ../cli/.github/releases/download/$(VERSION_VALUE)/op .
+	cp ../cli/.github/releases/download/$(VERSION_VALUE)/$(GOOS)$(subst amd,,$(GOARCH))-op ./op
+	chmod +x ./op
 
 .PHONY: install
 install:

--- a/metricbeat-tests/README.md
+++ b/metricbeat-tests/README.md
@@ -98,7 +98,7 @@ $ export STACK_VERSION=7.5.0                       # exports stack version as ru
 $ export METRICBEAT_VERSION=7.5.0                  # exports metricbeat version to be tested
 $ # export FEATURE=redis                           # exports which feature to run (default 'all')
 $ # export GOOS=darwin                             # exports your O.S. (default 'linux', valid: [darwin, linux, windows])
-$ # export GOARCH=64                               # exports your O.S. (default '64', valid: [64, 386])
+$ # export GOARCH=amd64                            # exports your O.S. (default 'amd64', valid: [amd64, 386])
 $ make -C metricbeat-tests install                 # installs tests dependencies
 $ make -C metricbeat-tests fetch-binary            # generates the binary from the repository
 $ make -C metricbeat-tests run-elastic-stack       # runs the stack for metricbeat

--- a/metricbeat-tests/README.md
+++ b/metricbeat-tests/README.md
@@ -97,6 +97,8 @@ $ make -C cli install                              # installs CLI dependencies
 $ export STACK_VERSION=7.5.0                       # exports stack version as runtime
 $ export METRICBEAT_VERSION=7.5.0                  # exports metricbeat version to be tested
 $ # export FEATURE=redis                           # exports which feature to run (default 'all')
+$ # export GOOS=darwin                             # exports your O.S. (default 'linux', valid: [darwin, linux, windows])
+$ # export GOARCH=64                               # exports your O.S. (default '64', valid: [64, 386])
 $ make -C metricbeat-tests install                 # installs tests dependencies
 $ make -C metricbeat-tests fetch-binary            # generates the binary from the repository
 $ make -C metricbeat-tests run-elastic-stack       # runs the stack for metricbeat

--- a/metricbeat-tests/README.md
+++ b/metricbeat-tests/README.md
@@ -94,8 +94,8 @@ At this moment, the CLI and the functional tests coexist in the same repository,
 ```shell
 $ export GO111MODULE=on                            # Go modules support
 $ make -C cli install                              # installs CLI dependencies
-$ export STACK_VERSION=7.5.0                       # exports stack version as runtime
-$ export METRICBEAT_VERSION=7.5.0                  # exports metricbeat version to be tested
+$ export STACK_VERSION=7.6.0                       # exports stack version as runtime
+$ export METRICBEAT_VERSION=7.6.0                  # exports metricbeat version to be tested
 $ # export FEATURE=redis                           # exports which feature to run (default 'all')
 $ # export GOOS=darwin                             # exports your O.S. (default 'linux', valid: [darwin, linux, windows])
 $ # export GOARCH=amd64                            # exports your O.S. (default 'amd64', valid: [amd64, 386])


### PR DESCRIPTION
## What is this PR doing?
It defines the environment in a proper manner so that the CI scripts AND the Makefile works properly.

## Why is it important?
It was not using the workspace for docker build after 300810ed0e8f0ed985216470ac2c15fb54fec9cc, so it was not possible to build the CLI from the tests side.

The CI error can be found here: as you can see here: https://apm-ci.elastic.co/blue/organizations/jenkins/beats%2Fpoc-metricbeat-functional-tests/detail/poc-metricbeat-functional-tests/131/pipeline/

## Author's checklist
- [x] CLI created using `make -C metricbeat-tests fetch-binary`
- [x] Functional tests run using `.ci/scripts/functional-test.sh`